### PR TITLE
Potential fix for code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/sistema-reservas/backend/src/api/auth/auth.routes.js
+++ b/sistema-reservas/backend/src/api/auth/auth.routes.js
@@ -5,14 +5,22 @@ const authController = require('./auth.controller');
 // Importamos la función exportada por defecto y la llamamos 'authenticate'.
 const authenticate = require('../../middleware/auth.middleware');
 
+// Rate Limiting configuration
+const rateLimit = require('express-rate-limit');
+const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutos
+  max: 100, // máximo 100 solicitudes por ventana
+  message: 'Demasiadas solicitudes desde esta IP. Por favor, inténtalo de nuevo más tarde.'
+});
+
 // POST /api/v1/auth/login (Pública)
-router.post('/login', authController.loginUser);
+router.post('/login', authLimiter, authController.loginUser);
 
 // GET /api/v1/auth/profile (Protegida)
 // Usamos el middleware 'authenticate' que acabamos de importar correctamente.
-router.get('/profile', authenticate, authController.getUserProfile);
+router.get('/profile', authLimiter, authenticate, authController.getUserProfile);
 
 // POST /api/v1/auth/logout (Protegida)
-router.post('/logout', authenticate, authController.logoutUser);
+router.post('/logout', authLimiter, authenticate, authController.logoutUser);
 
 module.exports = router;


### PR DESCRIPTION
Potential fix for [https://github.com/Cracklitrox/Capstone/security/code-scanning/5](https://github.com/Cracklitrox/Capstone/security/code-scanning/5)

To fix the issue, rate limiting should be added to the sensitive authentication-related endpoints, particularly `/login`, `/profile`, and `/logout`. The best way to do this in an Express router is to apply a rate-limiting middleware such as `express-rate-limit` to these routes. This can be done by importing `express-rate-limit`, creating a limiter instance (e.g., limiting requests to 100 per 15 minutes per IP), and applying the middleware directly to the routes. Changes will be made in `sistema-reservas/backend/src/api/auth/auth.routes.js`: add the `express-rate-limit` import, instantiate a limiter, and apply it to the routes by listing the limiter before the controllers in the relevant `router.post` and `router.get` calls.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
