### PR TITLE
Potential fix for code scanning alert no. 6: Missing rate limiting

### DIFF
--- a/sistema-reservas/backend/src/api/routes.js
+++ b/sistema-reservas/backend/src/api/routes.js
@@ -1,8 +1,19 @@
 const express = require('express');
 const router = express.Router();
 
+// Import express-rate-limit for rate limiting
+const rateLimit = require('express-rate-limit');
+
 const staffRoutes = require('./staff/staff.routes');
 const authRoutes = require('./auth/auth.routes');
+
+// Define specific rate limiter for staff routes
+const staffLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+  standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+  legacyHeaders: false,  // Disable the `X-RateLimit-*` headers
+});
 
 const authenticate = require('../middleware/auth.middleware');
 
@@ -12,6 +23,6 @@ router.get('/', (req, res) => {
 
 router.use('/auth', authRoutes);
 
-router.use('/staff', authenticate, staffRoutes);
+router.use('/staff', staffLimiter, authenticate, staffRoutes);
 
 module.exports = router;


### PR DESCRIPTION
Potential fix for [https://github.com/Cracklitrox/Capstone/security/code-scanning/6](https://github.com/Cracklitrox/Capstone/security/code-scanning/6)

To address the missing rate limiting, introduce rate-limiting middleware to the relevant routes. The recommended approach is to use the well-established `express-rate-limit` package. To minimally impact existing code and functionality, create a rate limiter with sensible defaults (e.g., 100 requests per 15 minutes per IP) and apply it specifically to the `/staff` route, immediately before the authentication middleware.

**Steps:**
- Import/use `express-rate-limit` in this file.
- Define a new rate limiter middleware (e.g., `staffLimiter`).
- Apply `staffLimiter` to the `/staff` route, so the chain becomes: `router.use('/staff', staffLimiter, authenticate, staffRoutes);`.
- Ensure the rest of the file and other routes remain unchanged.

No other code or logic needs to change, as the rate limiting will be encapsulated in its middleware.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
